### PR TITLE
Clean %hesitations

### DIFF
--- a/oratorio/coach/analyzer.py
+++ b/oratorio/coach/analyzer.py
@@ -48,6 +48,20 @@ class Analyzer:
             # Watson is set up so that this is always the first alternative
             final_sentence = sentence["alternatives"][0]
 
+            # Strip out the %HESITATION words from the data that Watson returns
+            found_hesitation = False
+            for word in final_sentence["timestamps"]:
+                if word[0].startswith("%"):
+                    final_sentence["timestamps"].remove(word)
+                    found_hesitation = True
+            # If a %HESITATION was found, rebuild the full sentence ignoring the %HESITATION
+            if found_hesitation:
+                sentence_transcript = ""
+                for word in final_sentence["timestamps"][:-1]:
+                    sentence_transcript += word[0] + " "
+                sentence += final_sentence["timestamps"][-1][0]
+                final_sentence["transcript"] = sentence_transcript
+
             transcript.append((final_sentence["transcript"], final_sentence["timestamps"],
                                final_sentence["confidence"]))
         return transcript

--- a/oratorio/coach/analyzer.py
+++ b/oratorio/coach/analyzer.py
@@ -59,7 +59,7 @@ class Analyzer:
                 sentence_transcript = ""
                 for word in final_sentence["timestamps"][:-1]:
                     sentence_transcript += word[0] + " "
-                sentence += final_sentence["timestamps"][-1][0]
+                sentence_transcript += final_sentence["timestamps"][-1][0]
                 final_sentence["transcript"] = sentence_transcript
 
             transcript.append((final_sentence["transcript"], final_sentence["timestamps"],

--- a/oratorio/coach/tests/test_analyzer.py
+++ b/oratorio/coach/tests/test_analyzer.py
@@ -16,7 +16,7 @@ class AnalyzerTestCase(TestCase):
         self.assertEquals(Analyzer.get_transcript_json("dumy-file", mock_stt), "mock result")
 
     def test_clean_transcript(self):
-        """Test the clean_trabscript method"""
+        """Test the clean_transcript method"""
         test_transcript = [
             {
                 'alternatives': [
@@ -65,6 +65,63 @@ class AnalyzerTestCase(TestCase):
             ('this is', [['this', 0, 1], ['is', 1, 2]], 0.664),
             ('a test', [['a', 2, 3], ['test', 3, 4]], 0.664)
         ])
+
+    def test_clean_hesitations(self):
+        """Test the clean_transcript method"""
+        test_transcript = [
+            {
+                'alternatives': [
+                    {
+                        'timestamps': [
+                            [
+                                'this',
+                                0,
+                                1
+                            ],
+                            [
+                                'is',
+                                1,
+                                2
+                            ]
+                        ],
+                        'confidence': 0.664,
+                        'transcript': 'this is'
+                    }
+                ],
+                'final': True
+            },
+            {
+                'alternatives': [
+                    {
+                        'timestamps': [
+                            [
+                                '%HESITATION',
+                                2,
+                                3
+                            ],
+                            [
+                                'a',
+                                3,
+                                4
+                            ],
+                            [
+                                'test',
+                                4,
+                                5
+                            ]
+                        ],
+                        'confidence': 0.664,
+                        'transcript': '%HESITATION a test'
+                    }
+                ],
+                'final': True
+            }
+        ]
+        self.assertEquals(Analyzer.clean_transcript(test_transcript), [
+            ('this is', [['this', 0, 1], ['is', 1, 2]], 0.664),
+            ('a test', [['a', 3, 4], ['test', 4, 5]], 0.664)
+        ])
+
 
     def setup(self):
         """Sets up the database for the analyzer"""
@@ -210,3 +267,4 @@ class AnalyzerTestCase(TestCase):
         self.assertEqual(tone_dictionary['joy'], 40)
         self.assertEqual(tone_dictionary['sadness'], 50)
         self.assertEqual(tone_dictionary['confident'], 60)
+

--- a/oratorio/coach/views.py
+++ b/oratorio/coach/views.py
@@ -69,10 +69,10 @@ def upload(request):
         recording = Recording.create(
             audio_dir=uploaded_file_url, speech=speech)
         recording.save()
-    except:
+    except Exception as e:
         # Delete empty speech if anything goes wrong
         speech.delete()
-        return HttpResponseBadRequest()
+        return HttpResponseBadRequest(e)
     return HttpResponse(str(recording.id))
 
 


### PR DESCRIPTION
@williambhot and I found out that Watson detects hesitations (not very reliably), and inserts '%HESITATION' into its results. We decided to remove all instances of this phenomenon. The work is carried out by clean_transcript().

Also, I wrote a test to make sure '%HESITATION' words are properly removed when clean_transcript() is called.